### PR TITLE
fix: blank tiles in pdf mitigation

### DIFF
--- a/src/extractHorizontalPathMatch.test.ts
+++ b/src/extractHorizontalPathMatch.test.ts
@@ -1,0 +1,26 @@
+import { extractHorizontalPathMatch } from './utils';
+
+describe('extractHorizontalPathMatch', () => {
+  it('should return null when the path is null or undefined', () => {
+    expect(extractHorizontalPathMatch(null)).toBeNull();
+    expect(extractHorizontalPathMatch(undefined)).toBeNull();
+  });
+
+  it('should return null when the path does not contain the expected D3 format', () => {
+    expect(extractHorizontalPathMatch('M10 10 L20 20')).toBeNull();
+    expect(extractHorizontalPathMatch('')).toBeNull();
+  });
+
+  it('should successfully extract the coordinate segment from a valid d3-sankey path', () => {
+    const mockD3Path = 'M0,15.5C50,15.5,50,30,100,30';
+    const match = extractHorizontalPathMatch(mockD3Path);
+
+    expect(match).not.toBeNull();
+
+    // The full regex match
+    expect(match![0]).toBe(',15.5C');
+
+    // The captured group (which is the specific coordinate you need)
+    expect(match![1]).toBe('15.5');
+  });
+});

--- a/src/sankey.ts
+++ b/src/sankey.ts
@@ -17,6 +17,8 @@ declare var LookerCharts: LookerChartUtils;
 
 interface Sankey extends VisualizationDefinition {
   svg?: any;
+  addError?: (error: any) => void;
+  clearErrors?: (group?: string) => void;
 }
 
 const vis: Sankey = {
@@ -65,36 +67,21 @@ const vis: Sankey = {
   },
   // Render in response to the data or settings changing
   updateAsync(data, element, config, queryResponse, details, doneRendering) {
-    if (this.clearErrors) {
-      this.clearErrors();
-    }
-
-    if (
-      !handleErrors(this, queryResponse, {
-        min_pivots: 0,
-        max_pivots: 0,
-        min_dimensions: 2,
-        max_dimensions: undefined,
-        min_measures: 1,
-        max_measures: 1,
-      })
-    ) {
-      doneRendering();
-      return;
-    }
-
-    if (!data || data.length === 0) {
-      if (this.addError) {
-        this.addError({
-          title: 'No Data',
-          message: 'The query returned no results.',
-        });
-      }
-      doneRendering();
-      return;
-    }
+    this.clearErrors?.();
 
     try {
+      if (
+        !handleErrors(this, queryResponse, {
+          min_pivots: 0,
+          max_pivots: 0,
+          min_dimensions: 2,
+          max_dimensions: undefined,
+          min_measures: 1,
+          max_measures: 1,
+        })
+      )
+        return;
+
       const width = element.clientWidth;
       const height = element.clientHeight;
 
@@ -108,10 +95,15 @@ const vis: Sankey = {
       const measure = queryResponse.fields.measure_like[0];
       const val_format = measure.value_format;
 
+      // config object is not set properly on DB-next
+      // unless a user interacts with the config. Just catch the case for now.
       if (typeof config.label_type === 'undefined') {
         config.label_type = 'name';
       }
 
+      //  The standard d3.ScaleOrdinal<string, {}>, causes error
+      // `no-inferred-empty-object-type  Explicit type parameter needs to be provided to the function call`
+      // https://stackoverflow.com/questions/31564730/typescript-with-d3js-with-definitlytyped
       const color = d3
         .scaleOrdinal<string[], string[]>()
         .range(config.color_range || vis.options.color_range.default);
@@ -127,6 +119,7 @@ const vis: Sankey = {
           [width - 1, height - 6],
         ]);
 
+      // TODO: Placeholder until @types catches up with sankey
       const newSankeyProps: any = sankeyInst;
       newSankeyProps.nodeSort(null);
 
@@ -152,6 +145,7 @@ const vis: Sankey = {
       const nodes = new Set();
 
       data.forEach(function (d: any) {
+        // variable number of dimensions
         const path: any[] = [];
         for (const dim of dimensions) {
           if (d[dim.name].value === null && !config.show_null_points) break;
@@ -159,18 +153,12 @@ const vis: Sankey = {
         }
         path.forEach(function (p: any, i: number) {
           if (i === path.length - 1) return;
-          const source: any =
-            path.slice(i, i + 1)[0] +
-            i +
-            `len:${path.slice(i, i + 1)[0].length}`;
-          const target: any =
-            path.slice(i + 1, i + 2)[0] +
-            (i + 1) +
-            `len:${path.slice(i + 1, i + 2)[0].length}`;
+          const source: any = `${path[i]}${i}len:${path[i].length}`;
+          const target: any = `${path[i + 1]}${i + 1}len:${path[i + 1].length}`;
 
           nodes.add(source);
           nodes.add(target);
-
+          // Setup drill links
           const drillLinks: Link[] = [];
           for (const key in d) {
             if (d[key].links) {
@@ -191,14 +179,20 @@ const vis: Sankey = {
 
       const nodesArray = Array.from(nodes.values());
 
+      const nodeIndexMap = new Map(
+        nodesArray.map((val, index) => [val, index])
+      );
+
       graph.links.forEach(function (d: Cell) {
-        d.source = nodesArray.indexOf(d.source);
-        d.target = nodesArray.indexOf(d.target);
+        d.source = nodeIndexMap.get(d.source);
+        d.target = nodeIndexMap.get(d.target);
       });
 
       graph.nodes = Array.from(nodes.values()).map((d: any) => {
+        const parts = d.split('len:');
+        const len = parseInt(parts[parts.length - 1], 10);
         return {
-          name: d.slice(0, d.split('len:')[1]),
+          name: d.slice(0, len),
         };
       });
 
@@ -210,6 +204,8 @@ const vis: Sankey = {
         .append('path')
         .attr('class', 'link')
         .attr('d', function (d: any) {
+          // Prevents exact horizontal sankey links from disappearing.
+          // See for reference https://github.com/d3/d3-sankey/issues/28
           const path = sankeyLinkHorizontal()(d);
           const match = path ? path.match(/,([^C]+)C/) : null;
           if (match && path && match.length === 2) {
@@ -233,6 +229,7 @@ const vis: Sankey = {
           });
         })
         .on('click', function (event: MouseEvent, d: Cell) {
+          // Add drill menu event
           const coords = d3.pointer(event);
           const eventDetails: object = {pageX: coords[0], pageY: coords[1]};
           LookerCharts.Utils.openDrillMenu({
@@ -245,7 +242,9 @@ const vis: Sankey = {
           d3.selectAll('.link').style('opacity', 0.4);
         });
 
+      // gradients https://bl.ocks.org/micahstubbs/bf90fda6717e243832edad6ed9f82814
       link.style('stroke', function (d: Cell, i: number) {
+        // make unique gradient ids
         const gradientID = 'gradient' + i;
 
         const startColor = color(d.source.name.replace(/ .*/, ''));
@@ -325,7 +324,9 @@ const vis: Sankey = {
             case 'name':
               return d.name;
             case 'name_value':
-              return `${d.name} (${!!val_format ? SSF(val_format, d.value) : d.value})`;
+              return `${
+                d.name
+              } (${!!val_format ? SSF(val_format, d.value) : d.value})`;
             default:
               return '';
           }
@@ -341,17 +342,14 @@ const vis: Sankey = {
       node.append('title').text(function (d: Cell) {
         return d.name + '\n' + d.value;
       });
-
-      doneRendering();
     } catch (error) {
-      console.error(error);
-      if (this.addError) {
-        this.addError({
-          title: 'Rendering Error',
-          message: 'An unexpected error occurred while drawing the chart.',
-        });
-      }
-
+      console.error('Sankey Rendering Error:', error);
+      this.addError?.({
+        title: 'Rendering Error',
+        message:
+          'An unexpected error occurred while drawing the visualization.',
+      });
+    } finally {
       doneRendering();
     }
   },

--- a/src/sankey.ts
+++ b/src/sankey.ts
@@ -1,5 +1,5 @@
 import {sankey, sankeyLinkHorizontal, sankeyLeft} from 'd3-sankey';
-import {handleErrors} from './utils';
+import {extractHorizontalPathMatch, handleErrors} from './utils';
 import {format as SSF} from 'ssf';
 import * as d3 from 'd3';
 
@@ -207,7 +207,7 @@ const vis: Sankey = {
           // Prevents exact horizontal sankey links from disappearing.
           // See for reference https://github.com/d3/d3-sankey/issues/28
           const path = sankeyLinkHorizontal()(d);
-          const match = path ? path.match(/,([^C]+)C/) : null;
+          const match = extractHorizontalPathMatch(path);
           if (match && path && match.length === 2) {
             const replacementValue = +match[1] + 0.01;
             const fixedPath = path.replace(match[1], '' + replacementValue);

--- a/src/sankey.ts
+++ b/src/sankey.ts
@@ -1,7 +1,7 @@
 import {sankey, sankeyLinkHorizontal, sankeyLeft} from 'd3-sankey';
 import {handleErrors} from './utils';
 import {format as SSF} from 'ssf';
-import * as d3 from "d3";
+import * as d3 from 'd3';
 
 import {
   Cell,
@@ -65,6 +65,10 @@ const vis: Sankey = {
   },
   // Render in response to the data or settings changing
   updateAsync(data, element, config, queryResponse, details, doneRendering) {
+    if (this.clearErrors) {
+      this.clearErrors();
+    }
+
     if (
       !handleErrors(this, queryResponse, {
         min_pivots: 0,
@@ -74,268 +78,282 @@ const vis: Sankey = {
         min_measures: 1,
         max_measures: 1,
       })
-    )
+    ) {
+      doneRendering();
       return;
-
-    const width = element.clientWidth;
-    const height = element.clientHeight;
-
-    const svg = this.svg
-      .html('')
-      .attr('width', '100%')
-      .attr('height', '100%')
-      .append('g');
-
-    const dimensions = queryResponse.fields.dimension_like;
-    const measure = queryResponse.fields.measure_like[0];
-    const val_format = measure.value_format;
-
-    // config object is not set properly on DB-next
-    // unless a user interacts with the config. Just catch the case for now.
-    if (typeof config.label_type === 'undefined') {
-      config.label_type = 'name';
     }
 
-    //  The standard d3.ScaleOrdinal<string, {}>, causes error
-    // `no-inferred-empty-object-type  Explicit type parameter needs to be provided to the function call`
-    // https://stackoverflow.com/questions/31564730/typescript-with-d3js-with-definitlytyped
-    const color = d3
-      .scaleOrdinal<string[], string[]>()
-      .range(config.color_range || vis.options.color_range.default);
-
-    const defs = svg.append('defs');
-
-    const sankeyInst = sankey()
-      .nodeAlign(sankeyLeft)
-      .nodeWidth(10)
-      .nodePadding(12)
-      .extent([
-        [1, 1],
-        [width - 1, height - 6],
-      ]);
-
-    // TODO: Placeholder until @types catches up with sankey
-    const newSankeyProps: any = sankeyInst;
-    newSankeyProps.nodeSort(null);
-
-    let link = svg
-      .append('g')
-      .attr('class', 'links')
-      .attr('fill', 'none')
-      .attr('stroke', '#fff')
-      .selectAll('path');
-
-    let node = svg
-      .append('g')
-      .attr('class', 'nodes')
-      .attr('font-family', 'sans-serif')
-      .attr('font-size', 10)
-      .selectAll('g');
-
-    const graph: any = {
-      nodes: [],
-      links: [],
-    };
-
-    const nodes = new Set();
-
-    data.forEach(function (d: any) {
-      // variable number of dimensions
-      const path: any[] = [];
-      for (const dim of dimensions) {
-        if (d[dim.name].value === null && !config.show_null_points) break;
-        path.push(d[dim.name].value + '');
+    if (!data || data.length === 0) {
+      if (this.addError) {
+        this.addError({
+          title: 'No Data',
+          message: 'The query returned no results.',
+        });
       }
-      path.forEach(function (p: any, i: number) {
-        if (i === path.length - 1) return;
-        const source: any =
-          path.slice(i, i + 1)[0] + i + `len:${path.slice(i, i + 1)[0].length}`;
-        const target: any =
-          path.slice(i + 1, i + 2)[0] +
-          (i + 1) +
-          `len:${path.slice(i + 1, i + 2)[0].length}`;
+      doneRendering();
+      return;
+    }
 
-        nodes.add(source);
-        nodes.add(target);
-        // Setup drill links
-        const drillLinks: Link[] = [];
-        for (const key in d) {
-          if (d[key].links) {
-            d[key].links.forEach((link: Link) => {
-              drillLinks.push(link);
-            });
-          }
-        }
+    try {
+      const width = element.clientWidth;
+      const height = element.clientHeight;
 
-        graph.links.push({
-          drillLinks: drillLinks,
-          source: source,
-          target: target,
-          value: +d[measure.name].value,
-        });
-      });
-    });
+      const svg = this.svg
+        .html('')
+        .attr('width', '100%')
+        .attr('height', '100%')
+        .append('g');
 
-    const nodesArray = Array.from(nodes.values());
+      const dimensions = queryResponse.fields.dimension_like;
+      const measure = queryResponse.fields.measure_like[0];
+      const val_format = measure.value_format;
 
-    graph.links.forEach(function (d: Cell) {
-      d.source = nodesArray.indexOf(d.source);
-      d.target = nodesArray.indexOf(d.target);
-    });
+      if (typeof config.label_type === 'undefined') {
+        config.label_type = 'name';
+      }
 
-    graph.nodes = Array.from(nodes.values()).map((d: any) => {
-      return {
-        name: d.slice(0, d.split('len:')[1]),
+      const color = d3
+        .scaleOrdinal<string[], string[]>()
+        .range(config.color_range || vis.options.color_range.default);
+
+      const defs = svg.append('defs');
+
+      const sankeyInst = sankey()
+        .nodeAlign(sankeyLeft)
+        .nodeWidth(10)
+        .nodePadding(12)
+        .extent([
+          [1, 1],
+          [width - 1, height - 6],
+        ]);
+
+      const newSankeyProps: any = sankeyInst;
+      newSankeyProps.nodeSort(null);
+
+      let link = svg
+        .append('g')
+        .attr('class', 'links')
+        .attr('fill', 'none')
+        .attr('stroke', '#fff')
+        .selectAll('path');
+
+      let node = svg
+        .append('g')
+        .attr('class', 'nodes')
+        .attr('font-family', 'sans-serif')
+        .attr('font-size', 10)
+        .selectAll('g');
+
+      const graph: any = {
+        nodes: [],
+        links: [],
       };
-    });
 
-    sankeyInst(graph);
+      const nodes = new Set();
 
-    link = link
-      .data(graph.links)
-      .enter()
-      .append('path')
-      .attr('class', 'link')
-      .attr('d', function (d: any) {
-        // Prevents exact horizontal sankey links from disappearing.
-        // See for reference https://github.com/d3/d3-sankey/issues/28
-        const path = sankeyLinkHorizontal()(d);
-        const match = path ? path.match(/,([^C]+)C/) : null;
-        if (match && path && match.length === 2) {
-          const replacementValue = +match[1] + 0.01;
-          const fixedPath = path.replace(match[1], '' + replacementValue);
-          return 'M' + -10 + ',' + -10 + fixedPath;
+      data.forEach(function (d: any) {
+        const path: any[] = [];
+        for (const dim of dimensions) {
+          if (d[dim.name].value === null && !config.show_null_points) break;
+          path.push(d[dim.name].value + '');
         }
-        return 'M' + -10 + ',' + -10 + path;
-      })
-      .style('opacity', 0.4)
-      .attr('stroke-width', function (d: Cell) {
-        return Math.max(1, d.width);
-      })
-      .on('mouseenter', function (this: any, d: Cell) {
-        svg.selectAll('.link').style('opacity', 0.05);
-        d3.select(this).style('opacity', 0.7);
-        svg.selectAll('.node').style('opacity', function (p: any) {
-          if (p === d.source) return 1;
-          if (p === d.target) return 1;
-          return 0.5;
+        path.forEach(function (p: any, i: number) {
+          if (i === path.length - 1) return;
+          const source: any =
+            path.slice(i, i + 1)[0] +
+            i +
+            `len:${path.slice(i, i + 1)[0].length}`;
+          const target: any =
+            path.slice(i + 1, i + 2)[0] +
+            (i + 1) +
+            `len:${path.slice(i + 1, i + 2)[0].length}`;
+
+          nodes.add(source);
+          nodes.add(target);
+
+          const drillLinks: Link[] = [];
+          for (const key in d) {
+            if (d[key].links) {
+              d[key].links.forEach((link: Link) => {
+                drillLinks.push(link);
+              });
+            }
+          }
+
+          graph.links.push({
+            drillLinks: drillLinks,
+            source: source,
+            target: target,
+            value: +d[measure.name].value,
+          });
         });
-      })
-      .on('click', function (event: MouseEvent, d: Cell) {
-        // Add drill menu event
-        const coords = d3.pointer(event);
-        const eventDetails: object = {pageX: coords[0], pageY: coords[1]};
-        LookerCharts.Utils.openDrillMenu({
-          links: d.drillLinks,
-          event: event,
-        });
-      })
-      .on('mouseleave', function (d: Cell) {
-        d3.selectAll('.node').style('opacity', 1);
-        d3.selectAll('.link').style('opacity', 0.4);
       });
 
-    // gradients https://bl.ocks.org/micahstubbs/bf90fda6717e243832edad6ed9f82814
-    link.style('stroke', function (d: Cell, i: number) {
-      // make unique gradient ids
-      const gradientID = 'gradient' + i;
+      const nodesArray = Array.from(nodes.values());
 
-      const startColor = color(d.source.name.replace(/ .*/, ''));
-      const stopColor = color(d.target.name.replace(/ .*/, ''));
+      graph.links.forEach(function (d: Cell) {
+        d.source = nodesArray.indexOf(d.source);
+        d.target = nodesArray.indexOf(d.target);
+      });
 
-      const linearGradient = defs
-        .append('linearGradient')
-        .attr('id', gradientID);
+      graph.nodes = Array.from(nodes.values()).map((d: any) => {
+        return {
+          name: d.slice(0, d.split('len:')[1]),
+        };
+      });
 
-      linearGradient
-        .selectAll('stop')
-        .data([
-          {offset: '10%', color: startColor},
-          {offset: '90%', color: stopColor},
-        ])
+      sankeyInst(graph);
+
+      link = link
+        .data(graph.links)
         .enter()
-        .append('stop')
-        .attr('offset', function (d: Cell) {
-          return d.offset;
+        .append('path')
+        .attr('class', 'link')
+        .attr('d', function (d: any) {
+          const path = sankeyLinkHorizontal()(d);
+          const match = path ? path.match(/,([^C]+)C/) : null;
+          if (match && path && match.length === 2) {
+            const replacementValue = +match[1] + 0.01;
+            const fixedPath = path.replace(match[1], '' + replacementValue);
+            return 'M' + -10 + ',' + -10 + fixedPath;
+          }
+          return 'M' + -10 + ',' + -10 + path;
         })
-        .attr('stop-color', function (d: Cell) {
-          return d.color;
+        .style('opacity', 0.4)
+        .attr('stroke-width', function (d: Cell) {
+          return Math.max(1, d.width);
+        })
+        .on('mouseenter', function (this: any, d: Cell) {
+          svg.selectAll('.link').style('opacity', 0.05);
+          d3.select(this).style('opacity', 0.7);
+          svg.selectAll('.node').style('opacity', function (p: any) {
+            if (p === d.source) return 1;
+            if (p === d.target) return 1;
+            return 0.5;
+          });
+        })
+        .on('click', function (event: MouseEvent, d: Cell) {
+          const coords = d3.pointer(event);
+          const eventDetails: object = {pageX: coords[0], pageY: coords[1]};
+          LookerCharts.Utils.openDrillMenu({
+            links: d.drillLinks,
+            event: event,
+          });
+        })
+        .on('mouseleave', function (d: Cell) {
+          d3.selectAll('.node').style('opacity', 1);
+          d3.selectAll('.link').style('opacity', 0.4);
         });
 
-      return 'url(#' + gradientID + ')';
-    });
+      link.style('stroke', function (d: Cell, i: number) {
+        const gradientID = 'gradient' + i;
 
-    node = node
-      .data(graph.nodes)
-      .enter()
-      .append('g')
-      .attr('class', 'node')
-      .on('mouseenter', function (d: Cell) {
-        svg.selectAll('.link').style('opacity', function (p: any) {
-          if (p.source === d) return 0.7;
-          if (p.target === d) return 0.7;
-          return 0.05;
-        });
-      })
-      .on('mouseleave', function (d: Cell) {
-        d3.selectAll('.link').style('opacity', 0.4);
+        const startColor = color(d.source.name.replace(/ .*/, ''));
+        const stopColor = color(d.target.name.replace(/ .*/, ''));
+
+        const linearGradient = defs
+          .append('linearGradient')
+          .attr('id', gradientID);
+
+        linearGradient
+          .selectAll('stop')
+          .data([
+            {offset: '10%', color: startColor},
+            {offset: '90%', color: stopColor},
+          ])
+          .enter()
+          .append('stop')
+          .attr('offset', function (d: Cell) {
+            return d.offset;
+          })
+          .attr('stop-color', function (d: Cell) {
+            return d.color;
+          });
+
+        return 'url(#' + gradientID + ')';
       });
 
-    node
-      .append('rect')
-      .attr('x', function (d: Cell) {
-        return d.x0;
-      })
-      .attr('y', function (d: Cell) {
-        return d.y0;
-      })
-      .attr('height', function (d: Cell) {
-        return Math.abs(d.y1 - d.y0);
-      })
-      .attr('width', function (d: Cell) {
-        return Math.abs(d.x1 - d.x0);
-      })
-      .attr('fill', function (d: Cell) {
-        return color(d.name.replace(/ .*/, ''));
-      })
-      .attr('stroke', '#555');
+      node = node
+        .data(graph.nodes)
+        .enter()
+        .append('g')
+        .attr('class', 'node')
+        .on('mouseenter', function (d: Cell) {
+          svg.selectAll('.link').style('opacity', function (p: any) {
+            if (p.source === d) return 0.7;
+            if (p.target === d) return 0.7;
+            return 0.05;
+          });
+        })
+        .on('mouseleave', function (d: Cell) {
+          d3.selectAll('.link').style('opacity', 0.4);
+        });
 
-    node
-      .append('text')
-      .attr('x', function (d: Cell) {
-        return d.x0 - 6;
-      })
-      .attr('y', function (d: Cell) {
-        return (d.y1 + d.y0) / 2;
-      })
-      .attr('dy', '0.35em')
-      .style('font-weight', 'bold')
-      .attr('text-anchor', 'end')
-      .style('fill', '#222')
-      .text(function (d: Cell) {
-        switch (config.label_type) {
-          case 'name':
-            return d.name;
-          case 'name_value':
-            return `${
-              d.name
-            } (${!!val_format ? SSF(val_format, d.value) : d.value})`;
-          default:
-            return '';
-        }
-      })
-      .filter(function (d: Cell) {
-        return d.x0 < width / 2;
-      })
-      .attr('x', function (d: Cell) {
-        return d.x1 + 6;
-      })
-      .attr('text-anchor', 'start');
+      node
+        .append('rect')
+        .attr('x', function (d: Cell) {
+          return d.x0;
+        })
+        .attr('y', function (d: Cell) {
+          return d.y0;
+        })
+        .attr('height', function (d: Cell) {
+          return Math.abs(d.y1 - d.y0);
+        })
+        .attr('width', function (d: Cell) {
+          return Math.abs(d.x1 - d.x0);
+        })
+        .attr('fill', function (d: Cell) {
+          return color(d.name.replace(/ .*/, ''));
+        })
+        .attr('stroke', '#555');
 
-    node.append('title').text(function (d: Cell) {
-      return d.name + '\n' + d.value;
-    });
-    doneRendering();
+      node
+        .append('text')
+        .attr('x', function (d: Cell) {
+          return d.x0 - 6;
+        })
+        .attr('y', function (d: Cell) {
+          return (d.y1 + d.y0) / 2;
+        })
+        .attr('dy', '0.35em')
+        .style('font-weight', 'bold')
+        .attr('text-anchor', 'end')
+        .style('fill', '#222')
+        .text(function (d: Cell) {
+          switch (config.label_type) {
+            case 'name':
+              return d.name;
+            case 'name_value':
+              return `${d.name} (${!!val_format ? SSF(val_format, d.value) : d.value})`;
+            default:
+              return '';
+          }
+        })
+        .filter(function (d: Cell) {
+          return d.x0 < width / 2;
+        })
+        .attr('x', function (d: Cell) {
+          return d.x1 + 6;
+        })
+        .attr('text-anchor', 'start');
+
+      node.append('title').text(function (d: Cell) {
+        return d.name + '\n' + d.value;
+      });
+
+      doneRendering();
+    } catch (error) {
+      console.error(error);
+      if (this.addError) {
+        this.addError({
+          title: 'Rendering Error',
+          message: 'An unexpected error occurred while drawing the chart.',
+        });
+      }
+
+      doneRendering();
+    }
   },
 };
 looker.plugins.visualizations.add(vis);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,16 @@
-import * as d3 from "d3";
+import * as d3 from 'd3';
 
 import {VisConfig, VisQueryResponse, VisualizationDefinition} from './types';
 import {fromSheetsToD3Format} from './currency_formatter';
 
 export {d3};
+
+export const extractHorizontalPathMatch = (
+  path: string | null | undefined
+): RegExpMatchArray | null => {
+  if (!path) return null;
+  return path.match(/,([^C]+)C/);
+};
 
 export const formatType = (valueFormat: string) => {
   const format = fromSheetsToD3Format(valueFormat);


### PR DESCRIPTION
fix: prevent export timeouts and resolve strict TypeScript errors

Adds `doneRendering()` to early return paths (configuration errors,  empty datasets) and wraps the main D3 layout engine in a try/catch block. This ensures Looker's headless browser always receives the completion signal, preventing dashboard export timeouts if rendering fails or returns early.
